### PR TITLE
Fix disconnectedCallback TypeError for _unsubscribeStateChanges

### DIFF
--- a/flightradar24-card.js
+++ b/flightradar24-card.js
@@ -56,7 +56,10 @@ class Flightradar24Card extends HTMLElement {
             this.cardState.hass = hass;
 
             if (!this._unsubscribeStateChanges) {
-                this._unsubscribeStateChanges = this.subscribeToStateChanges(hass);
+                this._unsubscribeStateChanges = true; // guard against re-entry while awaiting
+                this.subscribeToStateChanges(hass).then(unsub => {
+                    this._unsubscribeStateChanges = unsub;
+                });
             }
 
             if (this._updateRequired) {
@@ -110,7 +113,7 @@ class Flightradar24Card extends HTMLElement {
                 this._zoomCleanup();
                 this._zoomCleanup = null;
             }
-            if (this._unsubscribeStateChanges) {
+            if (this._unsubscribeStateChanges && typeof this._unsubscribeStateChanges === 'function') {
                 this._unsubscribeStateChanges();
                 this._unsubscribeStateChanges = null;
             }
@@ -393,10 +396,10 @@ class Flightradar24Card extends HTMLElement {
         }
     }
 
-    subscribeToStateChanges(hass) {
+    async subscribeToStateChanges(hass) {
         try {
             if (!this.cardState.config.test && this.cardState.config.update !== false) {
-                return hass.connection.subscribeEvents((event) => {
+                return await hass.connection.subscribeEvents((event) => {
                     try {
                         if (event.data.entity_id === this.cardState.config.flights_entity || event.data.entity_id === this.cardState.config.location_tracker) {
                             this._updateRequired = true;


### PR DESCRIPTION
## Summary

Fixes #28 — `disconnectedCallback` throws `TypeError: this._unsubscribeStateChanges is not a function` during page navigation.

## Root Cause

`hass.connection.subscribeEvents()` returns a `Promise<unsubscribe>`, not the unsubscribe function directly. The return value was stored as-is in `_unsubscribeStateChanges`, making it a Promise object — truthy (passes the `if` guard) but not callable.

## Changes

- **`subscribeToStateChanges()`** — made `async` and `await` the Promise from `subscribeEvents()`, so it always returns the actual unsubscribe function (or `() => {}`)
- **`set hass()`** — use `.then()` to store the resolved unsubscribe function, with a `true` sentinel to prevent re-entrant subscription while awaiting
- **`disconnectedCallback()`** — added `typeof === 'function'` check as a safety guard in case teardown races the async resolution

## Testing

Verified the fix resolves the console error on a Home Assistant 2026.3.1 instance with the card configured (radar hidden, US units).